### PR TITLE
standalone: add log rotate support for test data

### DIFF
--- a/aggregator/README.md
+++ b/aggregator/README.md
@@ -1,0 +1,21 @@
+# Aggregator benchmarking
+
+We provide a simple script to run up multiple input VMs sending via TCP to a single Calyptia Core aggregator VM.
+This is all configurable via the environment variables below:
+
+| Name | Description | Default |
+|------|-------------|---------|
+|INPUT_IMAGE_NAME| The image to use for each of the input VMs | <https://www.googleapis.com/compute/v1/projects/calyptia-infra/global/images/calyptia-vendor-comparison-ubuntu-2004> |
+|INPUT_MACHINE_TYPE| The GCP machine type for each of the input VMs | e2-highcpu-8 |
+|INPUT_VM_COUNT| The number of input VMs to run. | 3 |
+|INPUT_LOG_RATE| The number of log messages to generate per second on each input VM. | 2000 |
+|INPUT_LOG_SIZE| The size of each log message in bytes. | 1000 |
+|||
+|CORE_VM_NAME| The name of the aggregator VM instance to create | benchmark-instance-core |
+|CORE_IMAGE_NAME| The image to use for the aggregator VM. | <https://www.googleapis.com/compute/v1/projects/calyptia-infra/global/images/gold-calyptia-core-20220808152134-us> |
+|CORE_MACHINE_TYPE| The GCP machine type for each of the input VMs | e2-highcpu-32 |
+
+We require you to provide the following environment variables:
+
+- CALYPTIA_CLOUD_PROJECT_TOKEN: The Calyptia Cloud project token to use.
+- CALYPTIA_CLOUD_AGGREGATOR_NAME: The Calyptia Cloud aggregator name to use, this should be unique and not existing prior to running the script (remove and old ones if reusing)

--- a/aggregator/run-gcp-test.sh
+++ b/aggregator/run-gcp-test.sh
@@ -3,7 +3,7 @@ set -eu
 
 gcloud info
 
-INPUT_IMAGE_FAMILY=${INPUT_IMAGE_FAMILY:-calyptia-vendor-comparison}
+INPUT_IMAGE_NAME=${INPUT_IMAGE_NAME:-https://www.googleapis.com/compute/v1/projects/calyptia-infra/global/images/calyptia-vendor-comparison-ubuntu-2004}
 INPUT_MACHINE_TYPE=${INPUT_MACHINE_TYPE:-e2-highcpu-8}
 INPUT_VM_COUNT=${INPUT_VM_COUNT:-3}
 INPUT_LOG_RATE=${INPUT_LOG_RATE:-2000}
@@ -12,7 +12,9 @@ INPUT_LOG_SIZE=${INPUT_LOG_SIZE:-1000}
 SSH_USERNAME=${SSH_USERNAME:-ubuntu}
 
 CORE_VM_NAME=${CORE_VM_NAME:-benchmark-instance-core}
-CORE_IMAGE_FAMILY=${CORE_IMAGE_FAMILY:-gold-calyptia-core}
+# This should be the latest public image for the region you want to use
+# TODO: auto-PR to run gcloud compute images describe-from-family 'gold-calyptia-core' to retrieve latest and update here
+CORE_IMAGE_NAME=${CORE_IMAGE_NAME:-https://www.googleapis.com/compute/v1/projects/calyptia-infra/global/images/gold-calyptia-core-20220808152134-us}
 CORE_MACHINE_TYPE=${CORE_MACHINE_TYPE:-e2-highcpu-32}
 CORE_TCP_PORT=${CORE_TCP_PORT:-5000}
 CALYPTIA_CLOUD_PROJECT_TOKEN=${CALYPTIA_CLOUD_PROJECT_TOKEN:?}
@@ -37,14 +39,14 @@ if [[ "${SKIP_VM_CREATION:-no}" == "no" ]]; then
         VM_NAME="benchmark-instance-input-$index"
         gcloud compute instances delete "$VM_NAME" -q &> /dev/null || true
         gcloud compute instances create "$VM_NAME" \
-            --image-family="$INPUT_IMAGE_FAMILY" \
+            --image="$INPUT_IMAGE_NAME" \
             --machine-type="$INPUT_MACHINE_TYPE"
     done
 
     echo "Creating Core instance"
     gcloud compute instances delete "$CORE_VM_NAME" -q &> /dev/null || true
     gcloud compute instances create "$CORE_VM_NAME" \
-        --image-family="$CORE_IMAGE_FAMILY" \
+        --image="$CORE_IMAGE_NAME" \
         --machine-type="$CORE_MACHINE_TYPE" \
         --metadata=CALYPTIA_CLOUD_PROJECT_TOKEN="$CALYPTIA_CLOUD_PROJECT_TOKEN",CALYPTIA_CLOUD_AGGREGATOR_NAME="$CALYPTIA_CLOUD_AGGREGATOR_NAME"
     wait_for_ssh "$CORE_VM_NAME"

--- a/standalone/config/logrotate/logrotate-test.service
+++ b/standalone/config/logrotate/logrotate-test.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Rotate test log files
+ConditionACPower=true
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/bin/chmod 400 /test/logrotate.conf
+ExecStartPre=/usr/bin/chown root:root /test/logrotate.conf
+ExecStart=/usr/sbin/logrotate /test/logrotate.conf

--- a/standalone/config/logrotate/logrotate-test.timer
+++ b/standalone/config/logrotate/logrotate-test.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fast rotation of test input data
+
+[Timer]
+# Run every minute
+OnCalendar=*:0/1
+AccuracySec=1s
+Persistent=true
+# Unit=logrotate-test.service
+
+[Install]
+WantedBy=timers.target

--- a/standalone/packer.json.pkr.hcl
+++ b/standalone/packer.json.pkr.hcl
@@ -60,6 +60,11 @@ build {
     inline = ["/usr/bin/cloud-init status --wait"]
   }
 
+  provisioner "file" {
+    destination = "/tmp/"
+    source      = "./config/logrotate/"
+  }
+
   provisioner "shell" {
     execute_command = "echo 'packer' | {{ .Vars }} sudo -S -E bash '{{ .Path }}'"
     script          = "./scripts/provision.sh"

--- a/standalone/packer.json.pkr.hcl
+++ b/standalone/packer.json.pkr.hcl
@@ -70,7 +70,6 @@ build {
     source      = "./config/calyptia/"
   }
 
-  # For now we copy the same config to OSS
   provisioner "file" {
     destination = "/etc/fluent-bit/"
     source      = "./config/calyptia/"

--- a/standalone/scripts/provision.sh
+++ b/standalone/scripts/provision.sh
@@ -14,14 +14,10 @@ apt-get -y install apt-transport-https atop ca-certificates curl gpg lsb-release
 # apt-get -y upgrade
 
 # Handle test data log rotation every 5 minutes
-cat >> /etc/cron.d/calyptia << CRON_EOF
-# Added by Calyptia provisioning
-SHELL=/bin/sh
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+cp -fv /tmp/logrotate-test.* /lib/systemd/system/
+systemctl daemon-reload
+systemctl enable logrotate-test.timer
 
-*/5 * * * *	root    [ -f /test/logrotate.conf ] && /usr/sbin/logrotate /test/logrotate.conf >/dev/null
-#
-CRON_EOF
 ## Monitoring stack
 
 # Set up Docker repo

--- a/standalone/scripts/provision.sh
+++ b/standalone/scripts/provision.sh
@@ -13,6 +13,15 @@ apt-get -y install apt-transport-https atop ca-certificates curl gpg lsb-release
 # Do not upgrade as triggers connection problems
 # apt-get -y upgrade
 
+# Handle test data log rotation every 5 minutes
+cat >> /etc/cron.d/calyptia << CRON_EOF
+# Added by Calyptia provisioning
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+*/5 * * * *	root    [ -f /test/logrotate.conf ] && /usr/sbin/logrotate /test/logrotate.conf >/dev/null
+#
+CRON_EOF
 ## Monitoring stack
 
 # Set up Docker repo

--- a/standalone/test/logrotate.conf
+++ b/standalone/test/logrotate.conf
@@ -8,7 +8,7 @@ create
 /test/data/*.log
 {
     missingok
-    size 10G
+    size 5G
     rotate 1
     notifempty
 }
@@ -16,7 +16,7 @@ create
 /test/*.log
 {
     missingok
-    size 10G
+    size 5G
     rotate 1
     notifempty
 }

--- a/standalone/test/logrotate.conf
+++ b/standalone/test/logrotate.conf
@@ -1,0 +1,22 @@
+# use the adm group by default, since this is the owning group
+# of /var/log/syslog.
+su root adm
+
+# create new (empty) log files after rotating old ones
+create
+
+/test/data/*.log
+{
+    missingok
+    size 10G
+    rotate 1
+    notifempty
+}
+
+/test/*.log
+{
+    missingok
+    size 10G
+    rotate 1
+    notifempty
+}


### PR DESCRIPTION
Resolves #4 by adding log rotation to the input VMs so they do not fill up their test logs.
Also updates the aggregator script to use public images.